### PR TITLE
Fix octal escapes starting with 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,10 @@ import 'string.fromcodepoint';
  * | 
  *   (\d{3}) - fourth alternative; matches the 3-digit octal escape sequence (\512)
  * | 
- *   (['"tbrnfv0/\\]) - fifth alternative; matches the special escape characters (\t, \n and so on)
+ *   (['"tbrnfv0\\]) - fifth alternative; matches the special escape characters (\t, \n and so on)
  * )
  */
-const jsEscapeRegex = /\\(u\{([0-9A-Fa-f]+)\}|u([0-9A-Fa-f]{4})|x([0-9A-Fa-f]{2})|(\d{3})|(['"tbrnfv0/\\]))/g;
+const jsEscapeRegex = /\\(u\{([0-9A-Fa-f]+)\}|u([0-9A-Fa-f]{4})|x([0-9A-Fa-f]{2})|(\d{3})|(['"tbrnfv0\\]))/g;
 
 const usualEscapeSequences = {
     '0': '\0',

--- a/src/index.js
+++ b/src/index.js
@@ -33,17 +33,17 @@ const fromHex = (str) => String.fromCodePoint(parseInt(str, 16));
 const fromOct = (str) => String.fromCodePoint(parseInt(str, 8));
 
 export default (string) => {
-    return string.replace(jsEscapeRegex, (_, match, longHex, varHex, shortHex, octal) => {
-        if (shortHex !== undefined) {
-            return fromHex(shortHex);
-        } else if (varHex !== undefined) {
+    return string.replace(jsEscapeRegex, (_, __, varHex, longHex, shortHex, octal, specialCharacter) => {
+        if (varHex !== undefined) {
             return fromHex(varHex);
         } else if (longHex !== undefined) {
             return fromHex(longHex);
+        } else if (shortHex !== undefined) {
+            return fromHex(shortHex);
         } else if (octal !== undefined) {
             return fromOct(octal);
         } else {
-            return usualEscapeSequences[match];
+            return usualEscapeSequences[specialCharacter];
         }
     });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,20 @@
 import 'string.fromcodepoint';
 
-const jsEscapeRegex = /\\(u(\{([0-9A-Fa-f]+)\}|[0-9A-Fa-f]{4})|x([0-9A-Fa-f]{2})|(\d{3})|['"tbrnfv0/\\])/g;
+/**
+ * \\ - matches the backslash which indicates the beginning of an escape sequence
+ * (
+ *   u\{([0-9A-Fa-f]+)\} - first alternative; matches the variable-length hexadecimal escape sequence (\u{ABCD0})
+ * |
+ *   u([0-9A-Fa-f]{4}) - second alternative; matches the 4-digit hexadecimal escape sequence (\uABCD)
+ * | 
+ *   x([0-9A-Fa-f]{2}) - third alternative; matches the 2-digit hexadecimal escape sequence (\xA5)
+ * | 
+ *   (\d{3}) - fourth alternative; matches the 3-digit octal escape sequence (\512)
+ * | 
+ *   (['"tbrnfv0/\\]) - fifth alternative; matches the special escape characters (\t, \n and so on)
+ * )
+ */
+const jsEscapeRegex = /\\(u\{([0-9A-Fa-f]+)\}|u([0-9A-Fa-f]{4})|x([0-9A-Fa-f]{2})|(\d{3})|(['"tbrnfv0/\\]))/g;
 
 const usualEscapeSequences = {
     '0': '\0',

--- a/src/index.js
+++ b/src/index.js
@@ -1,55 +1,35 @@
 import 'string.fromcodepoint';
 
-const usualEscapeSequences = [
-    [/\\0/g, '\0'],
-    [/\\b/g, '\b'],
-    [/\\f/g, '\f'],
-    [/\\n/g, '\n'],
-    [/\\r/g, '\r'],
-    [/\\t/g, '\t'],
-    [/\\v/g, '\v'],
-    [/\\'/g, '\''],
-    [/\\"/g, '\"'],
-    [/\\\\/g, '\\']
-];
+const jsEscapeRegex = /\\(u(\{([0-9A-Fa-f]+)\}|[0-9A-Fa-f]{4})|x([0-9A-Fa-f]{2})|(\d{3})|['"tbrnfv0/\\])/g;
 
-const createUnescaper = (regexp, base) => {
-    return (stringToUnescape) => {
-        return stringToUnescape.replace(regexp, (_, submatch) => {
-            const charCode = parseInt(submatch, base);
-            return String.fromCodePoint(charCode);
-        });
-    }
-}
+const usualEscapeSequences = {
+    '0': '\0',
+    'b': '\b',
+    'f': '\f',
+    'n': '\n',
+    'r': '\r',
+    't': '\t',
+    'v': '\v',
+    '\'': '\'',
+    '"': '"',
+    '\\': '\\'
+};
 
-/**
- * Unescape octal sequences with constant 3-digit length (\017, \251 etc.)
- */
-const unescapeOctSequence = createUnescaper(/\\(\d\d\d)/g, 8);
-
-/**
- * Unescape hexadecimal sequences with constant 2-digit length (\xA9, \x72 etc.)
- */
-const unescapeShortHexSequence = createUnescaper(/\\x([0-9A-Fa-f]{2})/g, 16);
-
-/**
- * Unescape hexadecimal sequences with constant 4-digit length (\u12A9, \u0072 etc.)
- */
-const unescapeLongHexSequence = createUnescaper(/\\u([0-9A-Fa-f]{4})/g, 16);
-
-/**
- * Unescape hexadecimal sequences with variable length. (\u{A9}, \u{2F804} etc.)
- */
-const unescapeVariableHexSequence = createUnescaper(/\\u\{([0-9A-Fa-f]+)\}/g, 16);
+const fromHex = (str) => String.fromCodePoint(parseInt(str, 16));
+const fromOct = (str) => String.fromCodePoint(parseInt(str, 8));
 
 export default (string) => {
-    string = usualEscapeSequences.reduce((s, [sequence, equivalent]) => {
-        return s.replace(sequence, equivalent);
-    }, string);
-    
-    string = unescapeOctSequence(string);
-    string = unescapeShortHexSequence(string);
-    string = unescapeLongHexSequence(string);
-    string = unescapeVariableHexSequence(string);
-    return string;
+    return string.replace(jsEscapeRegex, (_, match, longHex, varHex, shortHex, octal) => {
+        if (shortHex !== undefined) {
+            return fromHex(shortHex);
+        } else if (varHex !== undefined) {
+            return fromHex(varHex);
+        } else if (longHex !== undefined) {
+            return fromHex(longHex);
+        } else if (octal !== undefined) {
+            return fromOct(octal);
+        } else {
+            return usualEscapeSequences[match];
+        }
+    });
 }

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ test('usual escape sequences', t => {
 test('octal escape sequences', t => {
     // '---S---' instead of '---\123---' because octal literals are prohibited in strict mode
     t.is(unescapeJs('---\\123---'), '---S---');
+    t.is(unescapeJs('---\\040---'), '--- ---');
 });
 
 test('short hex escape sequences', t => {
@@ -30,4 +31,9 @@ test('long hex escape sequences', t => {
 test('variable hex escape sequences', t => {
     t.is(unescapeJs('---\\u{A9}---'), '---\u{A9}---');
     t.is(unescapeJs('---\\u{2F804}---'), '---\u{2F804}---');
+});
+
+test('avoids double unescape cascade', t => {
+    t.is(unescapeJs('---\\\\x41---'), '---\\x41---');
+    t.is(unescapeJs('---\\x5cx41---'), '---\\x41---');
 });


### PR DESCRIPTION
Octal escape sequences starting with 0 should be expanded before the usual escape sequences to avoid ambiguity with the `\0` escape.

This patch aligns the behaviour with how JS parses the sequences.