### PR TITLE
Extract babel config into a .babelrc file

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.babelrc

--- a/package.json
+++ b/package.json
@@ -35,14 +35,6 @@
     "coveralls": "^2.11.9",
     "nyc": "^6.4.0"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "add-module-exports"
-    ]
-  },
   "dependencies": {
     "string.fromcodepoint": "^0.2.1"
   }


### PR DESCRIPTION
If anyone tries to pipe current version of `unescape-js` through babel with custom config they will be unable to do so since the local babel config placed inside the package.json will take precedence over any other config.
This is not ideal as not everyone excludes node_modules when running babel.
The fix is very simple: extract babel config into a `.babelrc` file and exclude this file when publishing to npm.